### PR TITLE
Add errorStateMatcher to input field

### DIFF
--- a/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.html
+++ b/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.html
@@ -19,11 +19,12 @@
     </button>
   </mat-menu>
 
-  <input type="tel" id="phone" autocomplete="off"
+  <input matInput type="tel" id="phone" autocomplete="off"
          [ngClass]="cssClass"
          (blur)="onTouched()"
          (keypress)="onInputKeyPress($event)"
          [(ngModel)]="phoneNumber"
          (ngModelChange)="onPhoneNumberChange()"
+         [errorStateMatcher]="errorStateMatcher"
          [disabled]="disabled" #focusable>
 </div>

--- a/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.ts
+++ b/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.ts
@@ -15,7 +15,7 @@ import {CountryCode, Examples} from './data/country-code';
 import {phoneNumberValidator} from './ngx-mat-intl-tel-input.validator';
 import {Country} from './model/country.model';
 import {getExampleNumber, parsePhoneNumberFromString, PhoneNumber} from 'libphonenumber-js';
-import {MatFormFieldControl} from '@angular/material';
+import {MatFormFieldControl, ErrorStateMatcher} from '@angular/material';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Subject} from 'rxjs';
 import {FocusMonitor} from '@angular/cdk/a11y';
@@ -42,6 +42,7 @@ export class NgxMatIntlTelInputComponent implements OnInit, OnDestroy, DoCheck, 
   @Input() name: string;
   @Input() onlyCountries: Array<string> = [];
   @Input() enableAutoCountrySelect = false;
+  @Input() errorStateMatcher: ErrorStateMatcher;
   private _placeholder: string;
   private _required = false;
   private _disabled = false;


### PR DESCRIPTION
You are now able to add a custom errorStateMatcher. For instance if you only want to validate the field on submit.