### PR TITLE
fix: phone number automatically removed when after was right validated

### DIFF
--- a/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.validator.ts
+++ b/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.validator.ts
@@ -13,7 +13,6 @@ export const phoneNumberValidator = (control: FormControl) => {
     }
 
     if (numberInstance && !numberInstance.isValid()) {
-      control.setValue(null);
       if (!control.touched) {
         control.markAsTouched();
       }


### PR DESCRIPTION
Hello! I found a bad user experience behavior e.g.: when a user enters more than the phone number digits required (e.g. 11 digits, instead of 10) the user should not have to re-enter the whole number. They should get a warning and be able to self correct where they left off