### PR TITLE
Enable support of theming by accessing to MatMenu subcomponent

### DIFF
--- a/projects/ngx-mat-intl-tel-input-tester/src/app/app.component.ts
+++ b/projects/ngx-mat-intl-tel-input-tester/src/app/app.component.ts
@@ -1,6 +1,7 @@
-import {Component} from '@angular/core';
+import {AfterViewInit, Component, ViewChild} from '@angular/core';
 import {FormGroup, FormControl, Validators} from '@angular/forms';
 import {FormBuilder} from '@angular/forms';
+import {NgxMatIntlTelInputComponent} from '../../../ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component';
 
 
 @Component({
@@ -8,7 +9,8 @@ import {FormBuilder} from '@angular/forms';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements AfterViewInit {
+  @ViewChild(NgxMatIntlTelInputComponent) phoneInput: NgxMatIntlTelInputComponent;
   phoneForm = new FormGroup({
     phone: new FormControl(undefined, [Validators.required]),
     name: new FormControl(undefined, [Validators.required]),
@@ -30,5 +32,9 @@ export class AppComponent {
 
   onReset() {
     this.phoneForm.reset();
+  }
+
+  ngAfterViewInit() {
+    this.phoneInput.matMenu.panelClass = 'custom-panel';
   }
 }

--- a/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.ts
+++ b/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.ts
@@ -10,7 +10,8 @@ import {
   OnInit,
   Optional,
   Output,
-  Self
+  Self,
+  ViewChild
 } from '@angular/core';
 
 import {FormGroupDirective, NG_VALIDATORS, NgControl, NgForm} from '@angular/forms';
@@ -24,6 +25,7 @@ import {Subject} from 'rxjs';
 import {FocusMonitor} from '@angular/cdk/a11y';
 import {CanUpdateErrorState, CanUpdateErrorStateCtor, ErrorStateMatcher, mixinErrorState} from '@angular/material/core';
 import {E164Number} from 'libphonenumber-js/types';
+import {MatMenu} from '@angular/material/menu';
 
 class NgxMatIntlTelInputBase {
   // tslint:disable-next-line:variable-name
@@ -68,6 +70,7 @@ export class NgxMatIntlTelInputComponent extends _NgxMatIntlTelInputMixinBase
   @Input() onlyCountries: Array<string> = [];
   @Input() errorStateMatcher: ErrorStateMatcher;
   @Input() enableSearch = false;
+  @ViewChild(MatMenu) matMenu: MatMenu;
   // tslint:disable-next-line:variable-name
   private _placeholder: string;
   // tslint:disable-next-line:variable-name


### PR DESCRIPTION
As Angular Material [supports theming](https://material.angular.io/guide/theming) we'd like to have ability to create a theme with a dark background for MatMenu that's used in this lib.

Having just `cssClass` input isn't enough, because MatMenu uses [cdk-overlay](https://material.angular.io/cdk/overlay/overview) which adds actual country list directly to the `<body>`'s root and applying any styles to the lib won't help.

In this PR I just made `matMenu` as publicity available API field and shown an example of usage. In the example, I add the class `.custom-panel` for cdk-overlay's panel in the body, so that anyone will be available to style the country list as they wish.