### PR TITLE
Enable searching by the dial code

### DIFF
--- a/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.html
+++ b/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.html
@@ -13,7 +13,7 @@
     </button>
     <mat-divider *ngIf="preferredCountriesInDropDown?.length"></mat-divider>
     <ng-container *ngFor="let country of allCountries">
-      <button type="button" mat-menu-item class="country-list-button" *ngIf="country.name | search:searchCriteria" (click)="onCountrySelect(country, focusable)">
+      <button type="button" mat-menu-item class="country-list-button" *ngIf="country | search:searchCriteria" (click)="onCountrySelect(country, focusable)">
         <div class="icon-wrapper">
           <div class="flag" [ngClass]="country.flagClass"></div>
         </div>

--- a/projects/ngx-mat-intl-tel-input/src/lib/search.pipe.ts
+++ b/projects/ngx-mat-intl-tel-input/src/lib/search.pipe.ts
@@ -1,17 +1,23 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+import { Country } from './model/country.model';
+
 @Pipe({
   name: 'search'
 })
 export class SearchPipe implements PipeTransform {
 
   // country | search:'searchCriteria'
-  transform(country: any, searchCriteria?: any): any {
+  transform(country: Country, searchCriteria?: string): boolean {
     if (!searchCriteria || searchCriteria === '') {
       return true;
     }
 
-    return country.toLowerCase().includes(searchCriteria.toLowerCase());
+    return `${country.name}+${country.dialCode}`
+      .toLowerCase()
+      .includes(
+        searchCriteria.toLowerCase()
+      );
   }
 
 }


### PR DESCRIPTION
It's an often case when users see the list of countries in the format `[Country_name] +[dialing_code]` and know the dialing code of the country they need, so they try to enter the code in the search bar and get nothing found. This PR fixes it.

I decided not to provide any additional config for it, as users who don't need it, just type the country name as before, the numbers won't affect them.