### PR TITLE
Implement "as-you-type" formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ If you want to show the sample number for the country selected or errors , use m
 | onlyCountries                 | ```string[]```         | ```[]```           | List of manually selected country abbreviations, which will appear in the dropdown. |                    |
 | enablePlaceholder             | ```boolean```          | ```true```         | Input placeholder text, which adapts to the country selected.                      |
 | enableSearch                  | ```boolean```          | ```false```        | Whether to display a search bar to help filter down the list of countries          |
+| format                        | ```string```           | ```default```      | Format of "as you type" input. Possible values: national, international, default    |
+
 
 ## Library Contributions
 

--- a/projects/ngx-mat-intl-tel-input/src/lib/model/phone-number-format.model.ts
+++ b/projects/ngx-mat-intl-tel-input/src/lib/model/phone-number-format.model.ts
@@ -1,0 +1,1 @@
+export type PhoneNumberFormat = 'default' | 'national' | 'international';


### PR DESCRIPTION
This PR adds support of `[format]` attribute to the component to support as-you-type phone number formatting.

Supported formats are:
- default (nothing is changed, national number w/o spaces or brackets)
- national (national number formatted based on the area rules, can be formatted with brackets, spaces etc.)
- international (full phone number starting with "+", formatted with spaces only)

![ezgif-6-07e6aae3e977](https://user-images.githubusercontent.com/1721577/92412005-d5838500-f152-11ea-8ba5-d2be49ffd671.gif)
