### PR TITLE
Placeholder for the input component

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ If you want to show the sample number for the country selected or errors , use m
 | ------------------------------|------------------------|--------------------|-------------------------------------------------------------------------------------|
 | preferredCountries            | ```string[]```         | ```[]```           | List of country abbreviations, which will appear at the top.                        |
 | onlyCountries                 | ```string[]```         | ```[]```           | List of manually selected country abbreviations, which will appear in the dropdown. |                    |
+| inputPlaceholder              | ```string```           | ```undefined```    | Placeholder for the input component.                                                |
 | enablePlaceholder             | ```boolean```          | ```true```         | Input placeholder text, which adapts to the country selected.                      |
 | enableSearch                  | ```boolean```          | ```false```        | Whether to display a search bar to help filter down the list of countries          |
 

--- a/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.html
+++ b/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.html
@@ -29,5 +29,6 @@
          [(ngModel)]="phoneNumber"
          (ngModelChange)="onPhoneNumberChange()"
          [errorStateMatcher]="errorStateMatcher"
+         [placeholder]="inputPlaceholder"
          [disabled]="disabled" #focusable>
 </div>

--- a/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.ts
+++ b/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.ts
@@ -65,6 +65,7 @@ export class NgxMatIntlTelInputComponent extends _NgxMatIntlTelInputMixinBase
 
   @Input() preferredCountries: Array<string> = [];
   @Input() enablePlaceholder = true;
+  @Input() inputPlaceholder: string;
   @Input() cssClass;
   @Input() name: string;
   @Input() onlyCountries: Array<string> = [];


### PR DESCRIPTION
This simple feature allows us to add `[inputPlaceholder]` as a placeholder of the actual material input (it's useful if the design of the project provides old-school placeholders instead of hints and labels)