### PR TITLE
Bug: Emit countryChanged event on enter full phone from other country

### DIFF
--- a/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.ts
+++ b/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.ts
@@ -194,6 +194,7 @@ export class NgxMatIntlTelInputComponent extends _NgxMatIntlTelInputMixinBase
         this.phoneNumber = this.numberInstance.nationalNumber;
         if (this.selectedCountry.iso2 !== this.numberInstance.country) {
           this.selectedCountry = this.getCountry(this.numberInstance.country);
+          this.countryChanged.emit(this.selectedCountry);
         }
       }
     } catch (e) {


### PR DESCRIPTION
The component allows to enter the full phone number in E164 format. If it detects a different country by the phone number, it selects the proper country automatically. But it didn't emit the countryChanged event. This PR fixes it.