### PR TITLE
fix positioning of selector with floating label

### DIFF
--- a/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.scss
+++ b/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.scss
@@ -56,13 +56,11 @@ input {
   height: initial;
   line-height: unset;
   width: 90px;
-  padding: 1px;
+  padding: 0px;
   opacity: 0;
   transition: opacity 200ms;
   position: absolute;
   z-index: 1;
-  top: 0;
-  bottom: 0;
   right: auto;
   left: 0;
   font: {


### PR DESCRIPTION
Compatibility with floating <mat-label> in <mat-form-field>: align country code with the rest of the input.

Examples for the following code:
```html
<mat-form-field>
   <mat-label>Mobile phone</mat-label>
   <ngx-mat-intl-tel-input</ngx-mat-intl-tel-input>
</mat-form-field>
```

# Without the fix:
![Screenshot_20230301_225339](https://user-images.githubusercontent.com/26513036/222280090-2502513f-ad13-45c2-88a1-aa2dbe1d544f.png)

# With the fix:
![Screenshot_20230301_232519](https://user-images.githubusercontent.com/26513036/222280121-fd781a88-725b-4fa4-93da-d8a0df8b08a9.png)
