### PR TITLE
Add an option to skip countries from being listed

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ If you want to show the sample number for the country selected or errors , use m
 | ------------------ | ---------- | ----------- | ----------------------------------------------------------------------------------- | --- |
 | preferredCountries | `string[]` | `[]`        | List of country abbreviations, which will appear at the top.                        |
 | onlyCountries      | `string[]` | `[]`        | List of manually selected country abbreviations, which will appear in the dropdown. |     |
+| skipCountries      | `string[]` | `[]`        | List of manually selected country abbreviations, which will NOT appear in the dropdown. |     |
 | inputPlaceholder   | `string`   | `undefined` | Placeholder for the input component.                                                |
 | enablePlaceholder  | `boolean`  | `true`      | Input placeholder text, which adapts to the country selected.                       |
 | enableSearch       | `boolean`  | `false`     | Whether to display a search bar to help filter down the list of countries           |

--- a/projects/ngx-mat-intl-tel-input-tester/src/app/app.component.html
+++ b/projects/ngx-mat-intl-tel-input-tester/src/app/app.component.html
@@ -103,6 +103,7 @@
         [enablePlaceholder]="true"
         [enableSearch]="true"
         [onlyCountries]="['us', 'cl', 've']"
+		[skipCountries]="['in']"
         [searchPlaceholder]="'Buscar...'"
         [formControl]="profileForm.controls.phone"
         placeholder="Enter Number"

--- a/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.ts
+++ b/projects/ngx-mat-intl-tel-input/src/lib/ngx-mat-intl-tel-input.component.ts
@@ -116,6 +116,7 @@ export class NgxMatIntlTelInputComponent
   @Input() cssClass: string | undefined;
   @Input() name: string | undefined;
   @Input() onlyCountries: Array<string> = [];
+  @Input() skipCountries: Array<string> = [];
   @Input() errorStateMatcher: ErrorStateMatcher = new ErrorStateMatcher();
   @Input() enableSearch = false;
   @Input() searchPlaceholder: string | undefined;
@@ -204,6 +205,11 @@ export class NgxMatIntlTelInputComponent
     if (this.onlyCountries.length) {
       this.allCountries = this.allCountries.filter((c) =>
         this.onlyCountries.includes(c.iso2)
+      );
+    }
+    if (this.skipCountries && this.skipCountries.length) {
+      this.allCountries = this.allCountries.filter((c) =>
+        !this.onlyCountries.includes(c.iso2)
       );
     }
     if (this.numberInstance && this.numberInstance.country) {


### PR DESCRIPTION
I came across a scenario in one of my projects where the client wants to skip showing some countries in the Phone Selection dropdown, due to some local regulations. There was no such option available in the library, so I am creating a Pull Request for the same - Hopefully it will help others as well. Thanks...